### PR TITLE
Fix deprecated fields in module json

### DIFF
--- a/module.json
+++ b/module.json
@@ -5,7 +5,7 @@
   "version": "0.2.3",
   "minimumCoreVersion": "9",
   "compatibleCoreVersion": "9",
-  "systems": ["pf1"],
+  "system": ["pf1"],
   "author": "fadedshadow589#8270",
   "url":"https://github.com/baileymh/statblock-library",
   "manifest": "https://github.com/baileymh/statblock-library/releases/download/0.2.3/module.json",

--- a/module.json
+++ b/module.json
@@ -19,7 +19,7 @@
       "label": "Bestiaries 1-3 (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-bestiaries1-3.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -27,7 +27,7 @@
       "label": "Bestiaries 4-6 (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-bestiaries4-6.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -35,7 +35,7 @@
       "label": "Companion and Campaign Settings (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-campaign-settings.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -43,7 +43,7 @@
       "label": "Emerald Spire Megadungeon (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-emerald-spire.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -51,7 +51,7 @@
       "label": "Monsters and Dragons (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-monsters-dragons.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -59,7 +59,7 @@
       "label": "Mythic Monsters (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-mythic-monsters.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -67,7 +67,7 @@
       "label": "NPCs and Villians (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-npcs-and-villians.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -75,7 +75,7 @@
       "label": "Occult Bestiary (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-occult-bestiary.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -83,7 +83,7 @@
       "label": "PFS (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-pfs.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },  
     {
@@ -91,7 +91,7 @@
       "label": "Rappan Athuk (FGG) (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-rappan-athuk.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -99,7 +99,7 @@
       "label": "Sword of Air (FGG) (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-sword-of-air.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },  
     {
@@ -107,7 +107,7 @@
       "label": "Tome of Horrors (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-tome-of-horrors.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -115,7 +115,7 @@
       "label": "The Lost City of Barakus (FGG) (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-lost-city-barakus.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },  
     {
@@ -123,7 +123,7 @@
       "label": "We Be Goblins (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-we-be-goblins.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -131,7 +131,7 @@
       "label": "AP - Carrion Crown (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-carrion-crown.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -139,7 +139,7 @@
       "label": "AP - Council of Thieves (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-council-of-thieves.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -147,7 +147,7 @@
       "label": "AP - Curse of the Crimson Throne (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-curse-crimson-throne.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -155,7 +155,7 @@
       "label": "AP - Giantslayer (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-giantslayer.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -163,7 +163,7 @@
       "label": "AP - Hell's Rebels (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-hells-rebels.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -171,7 +171,7 @@
       "label": "AP - Hell's Vengeance (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-hells-vengeance.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -179,7 +179,7 @@
       "label": "AP - Iron Gods (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-iron-gods.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -187,7 +187,7 @@
       "label": "AP - Ironfang Invasion (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-ironfang-invasion.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -195,7 +195,7 @@
       "label": "AP - Jade Regent (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-jade-regent.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -203,7 +203,7 @@
       "label": "AP - Kingmaker (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-kingmaker.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -211,7 +211,7 @@
       "label": "AP - Mummy's Mask (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-mummys-mask.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -219,7 +219,7 @@
       "label": "AP - Rise of the Runelords (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-rise-of-runelords.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -227,7 +227,7 @@
       "label": "AP - Serpent's Skull (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-serpents-skull.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -235,7 +235,7 @@
       "label": "AP - Skull & Shackles (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-skull-shackles.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -243,7 +243,7 @@
       "label": "AP - Shattered Star (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-shattered-star.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -251,7 +251,7 @@
       "label": "AP - Reign of Winter (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-reign-of-winter.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -259,7 +259,7 @@
       "label": "AP - Return of the Runelords (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-return-of-runelords.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -267,7 +267,7 @@
       "label": "AP - Ruins of Azlant (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-ruins-of-azlant.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -275,7 +275,7 @@
       "label": "AP - Strange Aeons (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-strange-aeons.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -283,7 +283,7 @@
       "label": "Tomb of the Iron Medusa (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-tomb-of-the-iron-medusa.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -291,7 +291,7 @@
       "label": "AP - Tyrant's Grasp (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-tyrants-grasp.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -299,7 +299,7 @@
       "label": "AP - War for the Crown (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-war-for-the-crown.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     },
     {
@@ -307,7 +307,7 @@
       "label": "AP - Wrath of the Righteous (Statblocks)",
       "system": "pf1",
       "path": "packs/sb-wrath-righteous.db",
-      "entity": "JournalEntry",
+      "type": "JournalEntry",
       "module": "statblock-library"
     }
   ]

--- a/module.json
+++ b/module.json
@@ -85,7 +85,7 @@
       "path": "packs/sb-pfs.db",
       "type": "JournalEntry",
       "module": "statblock-library"
-    },  
+    },
     {
       "name": "sb-rappan-athuk",
       "label": "Rappan Athuk (FGG) (Statblocks)",
@@ -101,7 +101,7 @@
       "path": "packs/sb-sword-of-air.db",
       "type": "JournalEntry",
       "module": "statblock-library"
-    },  
+    },
     {
       "name": "sb-tome-of-horrors",
       "label": "Tome of Horrors (Statblocks)",
@@ -117,7 +117,7 @@
       "path": "packs/sb-lost-city-barakus.db",
       "type": "JournalEntry",
       "module": "statblock-library"
-    },  
+    },
     {
       "name": "sb-we-be-goblins",
       "label": "We Be Goblins (Statblocks)",


### PR DESCRIPTION
I noticed that Foundry VTT complains about a few deprecated fields in the module.json.

- "systems" in the root. I can't find out when it was deprecated, but from what I gather, it has been "system" (singular) even before V9
- "entity" in the "packs" list. That one got changed to "type" with V9. Since statblock-library doesn't support 0.8.x anymore, this can be changed from "entity" to "type" directly

The final commit here just removed some trailing whitespace in the file module.json. Feel free to just ignore and remove that commit if you don't want whitespace changes.